### PR TITLE
changed rprm.trise setting in site.c to actually be rise time

### DIFF
--- a/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.aze.1.0/src/site.c
+++ b/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.aze.1.0/src/site.c
@@ -360,7 +360,7 @@ int SiteAzeStartIntt(int sec,int usec) {
 
   rprm.tbeam=bmnum;   
   rprm.tfreq=12000;   
-  rprm.trise=5000;   
+  rprm.trise=200;   
   rprm.baseband_samplerate=((double)nbaud/(double)txpl)*1E6; 
   rprm.filter_bandwidth=rprm.baseband_samplerate; 
   rprm.match_filter=1;

--- a/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.azw.1.0/src/site.c
+++ b/linux/home/radar/ros.3.6/usr/codebase/superdarn/src.lib/os/site.azw.1.0/src/site.c
@@ -360,7 +360,7 @@ int SiteAzwStartIntt(int sec,int usec) {
 
   rprm.tbeam=bmnum;   
   rprm.tfreq=12000;   
-  rprm.trise=5000;   
+  rprm.trise=200;   
   rprm.baseband_samplerate=((double)nbaud/(double)txpl)*1E6; 
   rprm.filter_bandwidth=rprm.baseband_samplerate; 
   rprm.match_filter=1;

--- a/qnx/root/operational_radar_code/ros/ddsserver_tcp_driver/load_filter_taps.c
+++ b/qnx/root/operational_radar_code/ros/ddsserver_tcp_driver/load_filter_taps.c
@@ -20,15 +20,15 @@
 
 extern int verbose;
 
-void load_filter_taps(FILE *ics660, uint32_t chip, uint32_t channel, int fc, double t_in)
+void load_filter_taps(FILE *ics660, uint32_t chip, uint32_t channel, int t_rise, double t_in)
 {
   struct ICS660_FILTER filter_str;
   if (verbose > 1) printf("  In Load filter taps file:%d chip:%d channel:%d trise:%d state:%lf\n"
-                          ,ics660,chip,channel,fc,t_in);	
+                          ,ics660,chip,channel,t_rise,t_in);	
 
   filter_str.chip = chip;
   filter_str.channel = channel;
-  filter_str.f_corner = fc;
+  filter_str.f_corner = 1e6 / t_rise; /* convert rise time in microseconds to corner frequency in hertz */
   filter_str.state_time = t_in;
 #ifdef __QNX__
   ics660_set_parameter((int)ics660,(int)ICS660_LOAD_FILTER,&filter_str,sizeof(filter_str));


### PR DESCRIPTION
The trise parameter in the ControlPRM struct set in in site.c in the usr/codebase/superdarn/src.lib/os/site.xxx/src folder is now actually rise time in microseconds. 

QNX still works in terms of corner frequency, which makes sense because that is how it calculates filter coefficents.
The ddsserver_tcp_driver on linux converts the rise time to a corner frequency and sends the time and sends that to qnx. Variables names for rise time calculations should no longer be actively misleading.

If you think the change from trise to fcutoff should happen somewhere else, I'm open to suggestions. 

The azores site.c files were modified as an example of what in site.c would need to be changed when applying this fix.
